### PR TITLE
Issue #860 - Updated relation to rc7

### DIFF
--- a/ting_reference.make
+++ b/ting_reference.make
@@ -9,7 +9,7 @@ projects[entityreference][subdir] = "contrib"
 projects[entityreference][version] = "1.1"
 
 projects[relation][subdir] = "contrib"
-projects[relation][version] = "1.0-rc5"
+projects[relation][version] = "1.0-rc7"
 
 projects[virtual_field][subdir] = "contrib"
 projects[virtual_field][version] = "1.2"


### PR DESCRIPTION
Update relation module to newer version do to error with drupal core 7.33 or newer.

See https://www.aakb.dk/search/ting/51466268#overlay=node/add/ding-news

Issue: http://platform.dandigbib.org/issues/860