### PR TITLE
Issue #1313 by cableman: Added extra check in reference update to keep references

### DIFF
--- a/ting_reference.module
+++ b/ting_reference.module
@@ -153,7 +153,7 @@ function ting_reference_field_update($entity_type, $entity, $field, $instance, $
       }
     }
 
-    // When nodes are saved problematically and edit form is not used the data
+    // When nodes are saved programmatically and edit form is not used the data
     // structure contains the relation and not item tid's (effect is that
     // reference are remove during scheduler publishing).
     if (!empty($item['value']) && isset($relations[$item['value']->rid])) {

--- a/ting_reference.module
+++ b/ting_reference.module
@@ -152,6 +152,13 @@ function ting_reference_field_update($entity_type, $entity, $field, $instance, $
         $clear_cache = TRUE;
       }
     }
+
+    // When nodes are saved problematically and edit form is not used the data
+    // structure contains the relation and not item tid's (effect is that
+    // reference are remove during scheduler publishing).
+    if (!empty($item['value']) && isset($relations[$item['value']->rid])) {
+      $keep[$item['value']->rid] = $item['value']->rid;
+    }
   }
 
   // Clear cache if needed.


### PR DESCRIPTION
This PR fixes an issue where all material references are deleted on auto publishing (pragmatically saving nodes).

See http://platform.dandigbib.org/issues/1313