### PR TITLE
Issue #835: Add pseudo delta support for relations.

### DIFF
--- a/ting_reference.module
+++ b/ting_reference.module
@@ -132,7 +132,8 @@ function ting_reference_field_update($entity_type, $entity, $field, $instance, $
   // Get existing relations.
   $relations = ting_reference_get_relations($entity_type, $entity);
 
-  // Delete all relations.
+  // Since there is no way to update the delta value of the endpoints, we need
+  // to delete all relations, and re-add them.
   foreach ($relations as $rid => $relation) {
     relation_delete($rid);
   }
@@ -144,6 +145,7 @@ function ting_reference_field_update($entity_type, $entity, $field, $instance, $
     }
   }
 
+  // Clear cache.
   field_cache_clear('field:' . $entity_type . ':' . $entity_id);
 }
 
@@ -427,6 +429,7 @@ function ting_reference_get_relations($entity_type, $entity) {
       ->condition('bundle', 'ting_reference')
       ->condition('endpoints_entity_type', $entity_type)
       ->condition('endpoints_entity_id', $entity_id)
+      ->orderBy('endpoints.entity_id')
       ->execute()
       ->fetchAllAssoc('entity_id');
 


### PR DESCRIPTION
Da det ikke umiddelbart er muligt at opdatere delta på relationerne, fikser dette PR problemet med rækkefølgen ved at slette alle relationer, for derefter at oprette dem igen.

Problemet bliver løst, men løsningen er en smule kontroversiel da:
1.) Det er ineffektivt at slette alle relationer, for derefter at oprette de samme igen.
2.) Hvis "en anden" har fat i en relation, vil denne reference forsvinde.
3.) Hvis der er metadata på selve relationen, udover dem som UI'et tilbyder, vil disse også forsvinde, da de ikke vil blive genskabt.

Vi har kørt med dette bug-fiks på Københanvs Kommuners biblioteker, og har ikke oplevet nogle issues.
